### PR TITLE
[RFC] Testing in Docker

### DIFF
--- a/assets/long-description.md
+++ b/assets/long-description.md
@@ -1,0 +1,32 @@
+# dynamodb
+
+Run DynamoDB locally with Docker, more details at [github.com/dwmkerr/docker-dynamodb](https://github.com/dwmkerr/dynamodb):
+
+```bash
+docker run -p 8000:8000 dwmkerr/dynamodb
+open http://localhost:8000/shell
+```
+
+Try it out by hitting the local shell:
+
+![DynamoDB Local Shell Screenshot](https://raw.githubusercontent.com/dwmkerr/docker-dynamodb/master/assets/banner.jpg)
+
+This container has full support for all of the commandline parameters in the [DynamoDB Documentation](http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html).
+
+# Instructions
+
+To run an ephemeral instance of DynamoDB:
+
+```bash
+docker run -p 8000:8000 dwmkerr/dynamodb
+```
+
+If you want to have persistent data, just mount a volume from your host and set it as a data directory for DynamoDB:
+
+```bash
+docker run -v /data:/data -p 8000:8000 dwmkerr/dynamodb -dbPath /data
+```
+
+# Coding
+
+For development instructions, check the GitHub page at [github.com/dwmkerr/docker-dynamodb](https://github.com/dwmkerr/docker-dynamodb).

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,14 @@
+FROM docker:1.12
+
+# Create a nice place to play
+RUN mkdir -p /opt/test
+WORKDIR /opt/test
+
+# Copy over our test scripts.
+COPY *.sh /opt/test/
+
+CMD \ 
+    docker load  && \
+	./test/basics.test.sh && \
+	./test/ephemeral.test.sh && \
+	./test/persistent.test.sh


### PR DESCRIPTION
I am aiming for a process where I can do this:

```bash
docker save dwmkerr/dynamodb | docker run --privileged  -t docker-dynamodb-tests
```

With the `docker-dynamodb-tests` Dockerfile ([./test/Dockerfile](./test/Dockerfile)) simply creating a container from the image for the tests to run against.

So far struggling to get the stdin/stdout transport. I could write the image to a file on the host and mount the data into the test container, but would prefer to avoid creating files if necessary...

If we can get this working, we can remove a lot of the container cleanup code and avoid messing with the host machine.