### PR TITLE
Document SharedDb option to help with SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ If you want to have persistent data, just mount a volume from your host and set 
 docker run -v /data:/data -p 8000:8000 dwmkerr/dynamodb -dbPath /data
 ```
 
+If you want to access tables and data created by the AWS CLI through a language SDK (Node, Java, etc), you will want to use the  `sharedDb` option [as described in this AWS forum post](https://forums.aws.amazon.com/thread.jspa?messageID=717048).
+
 # Coding
 
 The code is structued like this:


### PR DESCRIPTION
I ran into an issue where I couldn't see the tables I created from the AWS CLI when I used an SDK.
Landed on [that AWS forum post](https://forums.aws.amazon.com/thread.jspa?messageID=717048) which describes the issue better. Just relaying here in case you'd like to add to docs.

Thanks for this project!