### PR TITLE
Use alpine base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@
 # for details on how to run DynamoDB locally. This Dockerfile essentially
 # replicates those instructions.
 
-# Use JDK 7. I tried alpine, but all calls to dynamo then fail silently...
-# FROM openjdk:7-jre-alpine
-FROM openjdk:7
+FROM openjdk:8-jre-alpine
+
+# Specify dynamodb version with a build argument. (i.e. docker build . --build-arg DYNAMODB_VERSION=latest)
+ARG DYNAMODB_VERSION
 
 # Some metadata.
 MAINTAINER Dave Kerr <github.com/dwmkerr>
@@ -20,8 +21,14 @@ WORKDIR /opt/dynamodb
 
 # Download and unpack dynamodb.
 # Links are from: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html
-RUN wget https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_latest.tar.gz -q -O - | tar -xz
-  
+
+RUN wget https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_${DYNAMODB_VERSION}.tar.gz \
+    && wget https://s3-us-west-2.amazonaws.com/dynamodb-local/dynamodb_local_${DYNAMODB_VERSION}.tar.gz.sha256 \
+    && sha256sum -c dynamodb_local_${DYNAMODB_VERSION}.tar.gz.sha256 \
+    && tar zxvf dynamodb_local_${DYNAMODB_VERSION}.tar.gz \
+    && rm dynamodb_local_${DYNAMODB_VERSION}.tar.gz dynamodb_local_${DYNAMODB_VERSION}.tar.gz.sha256 
+
+ 
 # The entrypoint is the dynamodb jar. Default port is 8000.
 EXPOSE 8000
 ENTRYPOINT ["java", "-jar", "DynamoDBLocal.jar"]

--- a/README.md
+++ b/README.md
@@ -55,6 +55,13 @@ tests/         # bash scripts to test how the container works
 
 The Dockerfile is based on [OpenJDK](https://hub.docker.com/_/openjdk/) and essentially just runs a jar file in a JRSE 7 environment.
 
+When building the image, it will expect to have the desired dynamodb version set with a build argument of "DYNAMODB_VERSION".
+Example:
+```bash
+docker build --build-arg DYNAMODB_VERSION=latest .
+```
+
+
 ## The Makefile
 
 The makefile contains commands to build, test and deploy. Parameters can be passed as environment variables or through the commandline.

--- a/makefile
+++ b/makefile
@@ -1,11 +1,12 @@
 # Create the docker images locally. If a BUILD_NUM is provided, we will also
 # create an image with the tag BUILD_NUM.
+# Specify a specific dynamodb version by changing the DYNAMODB_VERSION=latest build flag as desired
 build:
-	docker build -t dwmkerr/dynamodb:latest .
+	docker build -t dwmkerr/dynamodb:latest --build-arg DYNAMODB_VERSION=latest .
 ifndef BUILD_NUM
 	$(warning No build number is defined, skipping build number tag.)
 else
-	docker build -t dwmkerr/dynamodb:$(BUILD_NUM) .	
+	docker build -t dwmkerr/dynamodb:$(BUILD_NUM) --build-arg DYNAMODB_VERSION=latest .	
 endif
 
 # Run the tests. These do things like kill containers, so run with caution.


### PR DESCRIPTION
This is to fix #19 
I took what @bradmccormack wrote but made DYNAMODB_VERSION a build arg instead, this way you can support multiple versions in your CI system without modifying the Dockerfile.